### PR TITLE
remove useEffect to fix render continuously in FlashMessage

### DIFF
--- a/components/elements/FlashMessages/FlashMessages.tsx
+++ b/components/elements/FlashMessages/FlashMessages.tsx
@@ -1,14 +1,16 @@
 import styles from './FlashMessages.module.scss';
 import * as React from 'react';
 import { IFlashMessagesProps } from '@/common/types';
-import { useEffect } from 'react';
 
 export const FlashMessages = ({
   flashMessages,
   setFlashMessages,
 }: IFlashMessagesProps): JSX.Element => {
   let messages;
-  let timer: number | undefined;
+
+  setTimeout(() => {
+    setFlashMessages([]);
+  }, 3000);
 
   if (flashMessages.length === 0) {
     messages = <></>;
@@ -23,13 +25,6 @@ export const FlashMessages = ({
       </div>
     );
   }
-
-  useEffect(() => {
-    timer = window.setTimeout(() => {
-      setFlashMessages([]);
-    }, 3000);
-    return () => window.clearTimeout(timer);
-  }, [flashMessages]);
 
   return messages;
 };


### PR DESCRIPTION
I think it doesn't need to use clearTimeout, so I remove the useEffect